### PR TITLE
Picked up food now marks the grid square as no longer occupied.

### DIFF
--- a/Assets/Scripts/FoodPickup.cs
+++ b/Assets/Scripts/FoodPickup.cs
@@ -6,15 +6,21 @@ public class FoodPickup : MonoBehaviour
 {
     [SerializeField] AudioClip foodPickupSFX;
     private bool addedToScore;
-
-
+    
     private void OnCollisionEnter2D(Collision2D collision)
     {
         Debug.Log("Food being eaten by: " + collision.gameObject);
         if (!addedToScore)
         {
+            var contactPoint = collision.GetContact(0);
+
+            Vector2Int collisionPosition = 
+                new Vector2Int(
+                    (int)Mathf.Round(contactPoint.point.x), 
+                    (int)Mathf.Round(contactPoint.point.y));
+
             addedToScore = true;
-            FindObjectOfType<GameController>().OnSnakeCollisionWithFood();
+            FindObjectOfType<GameController>().OnSnakeCollisionWithFood(collisionPosition);
             //AudioSource.PlayClipAtPoint(foodPickupSFX, Camera.main.transform.position);//future implementation of an audio effect
             Destroy(gameObject);
         }

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -224,11 +224,13 @@ public class GameController : MonoBehaviour
 
     // TODO: Make this function take the position of the food.
     // Then, it can call ConsumeItem().
-    public void OnSnakeCollisionWithFood()
+    public void OnSnakeCollisionWithFood(Vector2Int position)
     {
         // When the snake collides with a plant food, 
         // we want to increment the current food count of the snake.
         snake.IncrementCurrentFoodCount(1);
+
+        foodMap.MarkUnoccupied(position);
     }
 
     public void OnSnakeCollisionWithFlower()


### PR DESCRIPTION
This allows food to respawn at a location after the food that was spawned there is picked up.