### PR TITLE
Updated enemy movement after enemies spawn

### DIFF
--- a/Assets/Scenes/Play Scene.unity
+++ b/Assets/Scenes/Play Scene.unity
@@ -6030,7 +6030,7 @@ MonoBehaviour:
   flowerWiltThresholdInSeconds: 10
   flowerSecondsGainedPerFood: 5
   enemySpawnStartWait: 5
-  enemySpawnWait: 5
+  enemySpawnWait: 1
   rockObstacle: {fileID: 3463666963134266150, guid: 2f9952fb41d58684091263de52737ee8,
     type: 3}
   logObstacle: {fileID: 613168181323480149, guid: 8755ca2b4c3a8ee45afefe1053a70784,
@@ -6053,12 +6053,13 @@ MonoBehaviour:
   GameOverContainer: {fileID: 646712103}
   gameIsEnding: 0
   EnemyList: []
-  EnemyPoolLimit: 5
+  EnemyPoolLimit: 10
   playerScore: 0
   EnemyPrefab: {fileID: 1021393485587099968, guid: c3bed520332fae844b0e5b3246df7276,
     type: 3}
-  EnemyMovementCadenceSetting: 1
-  EnemyLifetimeSetting: 25
+  EnemyMovementCadenceSetting: 0.2
+  horizontalEnemyLifetime: 8.5
+  verticalEnemyLifetime: 4.75
   SnakeStunTime: 3
 --- !u!1 &2110593759
 GameObject:

--- a/Assets/Scripts/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySpawner.cs
@@ -3,16 +3,23 @@ using UnityEditor;
 
 public class EnemySpawner
 {
+    private float horizontalEnemyLifetime;
+    private float verticalEnemyLifetime;
     private int currentEnemiesSpawned;
     private int minRow = -5;
     private int maxRow = 5;
     private int minColumn = -9;
     private int maxColumn = 9;
 
-    public EnemySpawner()
+    public EnemySpawner(
+        float newHorizontalEnemyLifetime,
+        float newVerticalEnemyLifetime)
     {
         currentEnemiesSpawned = 0;
-    }
+
+        horizontalEnemyLifetime = newHorizontalEnemyLifetime;
+        verticalEnemyLifetime = newVerticalEnemyLifetime;
+}
 
     public bool ShouldSpawnEnemy(int CurrentWave)
     {
@@ -63,20 +70,38 @@ public class EnemySpawner
 
     private bool RandomBool() => (Random.Range(0, 2) == 1);
 
-    public Vector3 GetNewEnemyDirection()
+    public Vector3 GetNewEnemyDirection(Vector3 spawnPosition)
     {
+        // The enemy's direction will be based on their spawn position.
+        // The idea is that they should move directly across the board.
 
-        int x = RandomBool() ? 1 : 0;
-        int y = RandomBool() ? 1 : 0;
-        while (x + y == 0)
+        if (spawnPosition.x == minColumn)
         {
-            x = RandomBool() ? 1 : 0;
-            y = RandomBool() ? 1 : 0;
+            return new Vector3(1, 0, 0);
         }
-        x *= RandomBool() ? 1 : -1;
-        y *= RandomBool() ? 1 : -1;
 
-        return new Vector3(x, y, 0);
+        if (spawnPosition.x == maxColumn)
+        {
+            return new Vector3(-1, 0, 0);
+        }
 
+        if (spawnPosition.y == minRow)
+        {
+            return new Vector3(0, 1, 0);
+        }
+
+        Debug.Assert(spawnPosition.y == maxRow);
+        return new Vector3(0, -1, 0);
+    }
+
+    public float GetNewEnemyLifetime(Vector3 spawnPosition)
+    {
+        if ((spawnPosition.x == minColumn) || (spawnPosition.x == maxColumn))
+        {
+            return horizontalEnemyLifetime;
+        }
+
+        Debug.Assert((spawnPosition.y == maxRow) || (spawnPosition.y == minRow));
+        return verticalEnemyLifetime;
     }
 }

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -72,7 +72,8 @@ public class GameController : MonoBehaviour
 
     public GameObject EnemyPrefab;
     public float EnemyMovementCadenceSetting = 1f;
-    public float EnemyLifetimeSetting = 25f;
+    public float horizontalEnemyLifetime;
+    public float verticalEnemyLifetime;
 
     private bool snakeStunned = false;
     public float SnakeStunTime = 3;
@@ -114,7 +115,10 @@ public class GameController : MonoBehaviour
         background.CrossFadeAlpha(0f, 0f, true);
         GameOverContainer.SetActive(false);
 
-        enemySpawner = new EnemySpawner();
+        enemySpawner = 
+            new EnemySpawner(
+                horizontalEnemyLifetime,
+                verticalEnemyLifetime);
 
         StartCoroutine(SpawnEnemies());
 
@@ -382,9 +386,11 @@ public class GameController : MonoBehaviour
             {
                 Vector3 position = enemySpawner.GetNewEnemySpawnPosition();
 
-                Vector3 direction = enemySpawner.GetNewEnemyDirection();
+                Debug.Log($"***Spawning enemy at {position.x}, {position.y}***");
 
-                Debug.Log($"Spawning enemy at {position.x}, {position.y}");
+                Vector3 direction = enemySpawner.GetNewEnemyDirection(position);
+
+                float lifetime = enemySpawner.GetNewEnemyLifetime(position);
 
                 var enemy = EnemyList.FirstOrDefault(e => !e.activeInHierarchy);
                 if (enemy == null)
@@ -392,9 +398,8 @@ public class GameController : MonoBehaviour
                     enemy = Instantiate(EnemyPrefab, Vector3.zero, Quaternion.identity, EnemyContainer.transform);
                     EnemyList.Add(enemy);
                 }
-
                 
-                enemy.GetComponent<EnemyScript>().Initialize(position, direction, EnemyMovementCadenceSetting, EnemyLifetimeSetting);
+                enemy.GetComponent<EnemyScript>().Initialize(position, direction, EnemyMovementCadenceSetting, lifetime);
                 enemySpawner.OnEnemySpawned();
             }
 


### PR DESCRIPTION
Enemies now move in either vertical or hoizontal lines based on their spawn location. This is to keep the code simple.
Enemies lifetimes are set to expire as they get to the other side of the board.
Also, I upped the EnemyPoolLimit to 10 as the last wave (9) should be able to spawn up to 9 enemies at once.